### PR TITLE
Allows checking for errors on stream creation (issue #2)

### DIFF
--- a/lib/BaseRollingFileStream.js
+++ b/lib/BaseRollingFileStream.js
@@ -67,7 +67,11 @@ BaseRollingFileStream.prototype._write = function(chunk, encoding, callback) {
 
 BaseRollingFileStream.prototype.openTheStream = function(cb) {
   debug("opening the underlying stream");
+  var that = this;
   this.theStream = fs.createWriteStream(this.filename, this.options);
+  this.theStream.on('error', function(err) {
+    that.emit('error', err);
+  });
   if (cb) {
     this.theStream.on("open", cb);
   }

--- a/test/BaseRollingFileStream-test.js
+++ b/test/BaseRollingFileStream-test.js
@@ -46,6 +46,9 @@ describe('BaseRollingFileStream', function() {
               'fs': {
                 createWriteStream: function(filename, options) {
                   underlyingStreamOptions = options;
+                  return {
+                    on: function() {}
+                  };
                 }
               }
             }

--- a/test/read-only-file-test.js
+++ b/test/read-only-file-test.js
@@ -1,0 +1,28 @@
+"use strict";
+var should = require('should')
+, fs = require('fs')
+, path = require('path')
+, streamroller = require('../lib/index.js');
+
+describe('when the destination file is read-only', function() {
+  var testFile = path.join(__dirname, 'read-only-file.log');
+  before(function() {
+      fs.writeFileSync(
+        testFile,
+        "Some test content"
+      );
+      fs.chmodSync(testFile, 292 /* 0o444 - octal literals not allowed in old node */);
+  });
+
+  it('should generate an error when writing', function(done) {
+    var stream = new streamroller.RollingFileStream(testFile);
+    stream.on('error', function(e) {
+      e.code.should.eql('EACCES');
+      done();
+    });
+  });
+
+  after(function() {
+    fs.unlinkSync(testFile);
+  });
+});


### PR DESCRIPTION
This is a fix for issue #2 - where the caller could not catch an exception that happens when the underlying stream is created. 