### PR TITLE
Days to keep

### DIFF
--- a/lib/DateRollingFileStream.js
+++ b/lib/DateRollingFileStream.js
@@ -67,7 +67,7 @@ DateRollingFileStream.prototype.roll = function (filename, callback) {
     this.filename = this.baseFilename + this.lastTimeWeWroteSomething;
     this.closeTheStream(
       this.compressIfNeeded.bind(this, filename,
-        removeOldFiles.bind(this,
+        this.removeOldFiles.bind(this,
           this.openTheStream.bind(this, callback))));
   } else {
     var newFilename = this.baseFilename + this.previousTime;
@@ -75,31 +75,8 @@ DateRollingFileStream.prototype.roll = function (filename, callback) {
       deleteAnyExistingFile.bind(null,
         renameTheCurrentFile.bind(null,
           this.compressIfNeeded.bind(this, newFilename,
-            removeOldFiles.bind(this,
+            this.removeOldFiles.bind(this,
               this.openTheStream.bind(this, callback))))));
-  }
-
-  function removeOldFiles(cb) {
-    if (this.options.daysToKeep && this.options.daysToKeep > 0) {
-      var oldestDate = this.now() - (this.options.daysToKeep * (24 * 60 * 60 * 1000));
-
-      // Loop through any log files and delete any whose mtime is earlier than oldestDate
-      var dirToScan = path.dirname(this.baseFilename);
-      var fileToMatch = path.basename(this.baseFilename);
-      var filesToCheck = fs.readdirSync(dirToScan).filter(function (file) {
-        return file.indexOf(fileToMatch) > -1;
-      });
-      for (var i = 0; i < filesToCheck.length; i++) {
-        if (filesToCheck[i].startsWith(fileToMatch)) {
-          var fileToCheck = path.join(dirToScan, filesToCheck[i]);
-          var fileStats = fs.statSync(fileToCheck);
-          if (fileStats.mtime < oldestDate) {
-            fs.unlinkSync(fileToCheck);
-          }
-        }
-      }
-    }
-    cb();
   }
 
   function deleteAnyExistingFile(cb) {
@@ -126,3 +103,30 @@ DateRollingFileStream.prototype.compressIfNeeded = function (filename, cb) {
     cb();
   }
 };
+
+DateRollingFileStream.prototype.removeOldFiles = function (cb) {
+  debug("Checking if we need to delete old files");
+  if (this.options.daysToKeep && this.options.daysToKeep > 0) {
+    var oldestDate = new Date(this.now() - (this.options.daysToKeep * (24 * 60 * 60 * 1000)));
+    debug("Will delete any log files modified before ", oldestDate.toString());
+
+    // Loop through any log files and delete any whose mtime is earlier than oldestDate
+    var dirToScan = path.dirname(this.baseFilename);
+    var fileToMatch = path.basename(this.baseFilename);
+    var filesToCheck = fs.readdirSync(dirToScan).filter(function (file) {
+      return file.indexOf(fileToMatch) > -1;
+    });
+    for (var i = 0; i < filesToCheck.length; i++) {
+      if (filesToCheck[i].startsWith(fileToMatch)) {
+        var fileToCheck = path.join(dirToScan, filesToCheck[i]);
+        var fileStats = fs.statSync(fileToCheck);
+        if (fileStats.mtime < oldestDate) {
+          debug("Deleting old log ", filesToCheck);
+          fs.unlinkSync(fileToCheck);
+        }
+      }
+    }
+  }
+  cb();
+};
+

--- a/lib/DateRollingFileStream.js
+++ b/lib/DateRollingFileStream.js
@@ -1,100 +1,126 @@
 "use strict";
 var BaseRollingFileStream = require('./BaseRollingFileStream')
-, debug = require('debug')('streamroller:DateRollingFileStream')
-, format = require('date-format')
-, fs = require('fs')
-, util = require('util');
+    , debug = require('debug')('streamroller:DateRollingFileStream')
+    , format = require('date-format')
+    , fs = require('fs')
+    , path = require('path')
+    , util = require('util');
 
 module.exports = DateRollingFileStream;
 
 function findTimestampFromFileIfExists(filename, now) {
-  return fs.existsSync(filename) ? fs.statSync(filename).mtime : new Date(now());
+    return fs.existsSync(filename) ? fs.statSync(filename).mtime : new Date(now());
 }
 
 function DateRollingFileStream(filename, pattern, options, now) {
-  debug("Now is ", now);
-  if (pattern && typeof(pattern) === 'object') {
-    now = options;
-    options = pattern;
-    pattern = null;
-  }
-  this.pattern = pattern || '.yyyy-MM-dd';
-  this.now = now || Date.now;
-  this.lastTimeWeWroteSomething = format.asString(
-    this.pattern,
-    findTimestampFromFileIfExists(filename, this.now)
-  );
-
-  this.baseFilename = filename;
-  this.alwaysIncludePattern = false;
-
-  if (options) {
-    if (options.alwaysIncludePattern) {
-      this.alwaysIncludePattern = true;
-      filename = this.baseFilename + this.lastTimeWeWroteSomething;
+    debug("Now is ", now);
+    if (pattern && typeof(pattern) === 'object') {
+        now = options;
+        options = pattern;
+        pattern = null;
     }
-    delete options.alwaysIncludePattern;
-    if (Object.keys(options).length === 0) {
-      options = null;
-    }
-  }
-  debug("this.now is ", this.now, ", now is ", now);
+    this.pattern = pattern || '.yyyy-MM-dd';
+    this.now = now || Date.now;
+    this.lastTimeWeWroteSomething = format.asString(
+        this.pattern,
+        findTimestampFromFileIfExists(filename, this.now)
+    );
 
-  DateRollingFileStream.super_.call(this, filename, options);
+    this.baseFilename = filename;
+    this.alwaysIncludePattern = false;
+
+    if (options) {
+        if (options.alwaysIncludePattern) {
+            this.alwaysIncludePattern = true;
+            filename = this.baseFilename + this.lastTimeWeWroteSomething;
+        }
+        delete options.alwaysIncludePattern;
+        if (Object.keys(options).length === 0) {
+            options = null;
+        }
+    }
+    debug("this.now is ", this.now, ", now is ", now);
+
+    DateRollingFileStream.super_.call(this, filename, options);
 }
 util.inherits(DateRollingFileStream, BaseRollingFileStream);
 
-DateRollingFileStream.prototype.shouldRoll = function() {
-  var lastTime = this.lastTimeWeWroteSomething,
-  thisTime = format.asString(this.pattern, new Date(this.now()));
+DateRollingFileStream.prototype.shouldRoll = function () {
+    var lastTime = this.lastTimeWeWroteSomething,
+        thisTime = format.asString(this.pattern, new Date(this.now()));
 
-  debug("DateRollingFileStream.shouldRoll with now = ",
+    debug("DateRollingFileStream.shouldRoll with now = ",
         this.now(), ", thisTime = ", thisTime, ", lastTime = ", lastTime);
 
-  this.lastTimeWeWroteSomething = thisTime;
-  this.previousTime = lastTime;
+    this.lastTimeWeWroteSomething = thisTime;
+    this.previousTime = lastTime;
 
-  return thisTime !== lastTime;
+    return thisTime !== lastTime;
 };
 
-DateRollingFileStream.prototype.roll = function(filename, callback) {
-  var that = this;
+DateRollingFileStream.prototype.roll = function (filename, callback) {
+    var that = this;
 
-  debug("Starting roll");
+    debug("Starting roll");
 
-  if (this.alwaysIncludePattern) {
-    this.filename = this.baseFilename + this.lastTimeWeWroteSomething;
-    this.closeTheStream(this.openTheStream.bind(this, callback));
-  } else {
-    var newFilename = this.baseFilename + this.previousTime;
-    this.closeTheStream(
-      deleteAnyExistingFile.bind(null,
-        renameTheCurrentFile.bind(null,
-          this.compressIfNeeded.bind(this, newFilename,
-            this.openTheStream.bind(this,
-              callback)))));
-  }
+    if (this.alwaysIncludePattern) {
+        this.filename = this.baseFilename + this.lastTimeWeWroteSomething;
+        this.closeTheStream(this.openTheStream.bind(this, callback));
+    } else {
+        var newFilename = this.baseFilename + this.previousTime;
+        this.closeTheStream(
+            deleteAnyExistingFile.bind(null,
+                renameTheCurrentFile.bind(null,
+                    this.compressIfNeeded.bind(this, newFilename,
+                        removeOldFiles.bind(this,
+                            this.openTheStream.bind(this,
+                                callback))))));
+    }
 
-  function deleteAnyExistingFile(cb) {
-    //on windows, you can get a EEXIST error if you rename a file to an existing file
-    //so, we'll try to delete the file we're renaming to first
-    fs.unlink(newFilename, function (err) {
-      //ignore err: if we could not delete, it's most likely that it doesn't exist
-      cb();
-    });
-  }
+    function removeOldFiles(cb) {
+        if (this.options.daysToKeep) {
+            var oldestDate = this.now() - (this.options.daysToKeep * (24 * 60 * 60 * 1000));
 
-  function renameTheCurrentFile(cb) {
-    debug("Renaming the ", filename, " -> ", newFilename);
-    fs.rename(filename, newFilename, cb);
-  }
+            // Loop through any log files and delete any whose mtime is earlier than oldestDate
+            var dirToScan = path.dirname(this.baseFilename);
+            var fileToMatch = path.basename(this.baseFilename);
+            var filesToCheck = fs.readdirSync(dirToScan).filter(function (file) {
+                return file.indexOf(fileToMatch) > -1;
+            });
+            for (var i = 0; i < filesToCheck.length; i++) {
+                if (filesToCheck[i].startsWith(fileToMatch)) {
+                    var fileToCheck = path.join(dirToScan, filesToCheck[i]);
+                    var fileStats = fs.statSync(fileToCheck);
+                    if (fileStats.mtime < oldestDate) {
+                        fs.unlinkSync(fileToCheck);
+                    }
+                }
+            }
+        }
+        cb();
+    }
+
+    function deleteAnyExistingFile(cb) {
+        //on windows, you can get a EEXIST error if you rename a file to an existing file
+        //so, we'll try to delete the file we're renaming to first
+        fs.unlink(newFilename, function (err) {
+
+            //ignore err: if we could not delete, it's most likely that it doesn't exist
+            cb();
+        });
+    }
+
+    function renameTheCurrentFile(cb) {
+        debug("Renaming the ", filename, " -> ", newFilename);
+        fs.rename(filename, newFilename, cb);
+    }
 };
 
-DateRollingFileStream.prototype.compressIfNeeded = function(filename, cb) {
-  debug("Checking if we need to compress the old file");
-  if (this.options.compress) {
-    this.compress(filename, cb);
-  } else {
-    cb();
-  }
+DateRollingFileStream.prototype.compressIfNeeded = function (filename, cb) {
+    debug("Checking if we need to compress the old file");
+    if (this.options.compress) {
+        this.compress(filename, cb);
+    } else {
+        cb();
+    }
 };

--- a/lib/DateRollingFileStream.js
+++ b/lib/DateRollingFileStream.js
@@ -67,7 +67,7 @@ DateRollingFileStream.prototype.roll = function (filename, callback) {
     this.filename = this.baseFilename + this.lastTimeWeWroteSomething;
     this.closeTheStream(
       this.compressIfNeeded.bind(this, filename,
-        this.removeOldFiles.bind(this,
+        this.removeOldFilesIfNeeded.bind(this,
           this.openTheStream.bind(this, callback))));
   } else {
     var newFilename = this.baseFilename + this.previousTime;
@@ -75,7 +75,7 @@ DateRollingFileStream.prototype.roll = function (filename, callback) {
       deleteAnyExistingFile.bind(null,
         renameTheCurrentFile.bind(null,
           this.compressIfNeeded.bind(this, newFilename,
-            this.removeOldFiles.bind(this,
+            this.removeOldFilesIfNeeded.bind(this,
               this.openTheStream.bind(this, callback))))));
   }
 
@@ -104,29 +104,35 @@ DateRollingFileStream.prototype.compressIfNeeded = function (filename, cb) {
   }
 };
 
-DateRollingFileStream.prototype.removeOldFiles = function (cb) {
+DateRollingFileStream.prototype.removeOldFilesIfNeeded = function (cb) {
   debug("Checking if we need to delete old files");
   if (this.options.daysToKeep && this.options.daysToKeep > 0) {
     var oldestDate = new Date(this.now() - (this.options.daysToKeep * (24 * 60 * 60 * 1000)));
     debug("Will delete any log files modified before ", oldestDate.toString());
 
-    // Loop through any log files and delete any whose mtime is earlier than oldestDate
-    var dirToScan = path.dirname(this.baseFilename);
-    var fileToMatch = path.basename(this.baseFilename);
-    var filesToCheck = fs.readdirSync(dirToScan).filter(function (file) {
-      return file.indexOf(fileToMatch) > -1;
-    });
-    for (var i = 0; i < filesToCheck.length; i++) {
-      if (filesToCheck[i].startsWith(fileToMatch)) {
-        var fileToCheck = path.join(dirToScan, filesToCheck[i]);
-        var fileStats = fs.statSync(fileToCheck);
-        if (fileStats.mtime < oldestDate) {
-          debug("Deleting old log ", filesToCheck);
-          fs.unlinkSync(fileToCheck);
-        }
-      }
-    }
+    this.removeFilesOlderThan(oldestDate);
   }
   cb();
 };
+
+DateRollingFileStream.prototype.removeFilesOlderThan = function (oldestDate) {
+
+  // Loop through any log files and delete any whose mtime is earlier than oldestDate
+  var dirToScan = path.dirname(this.baseFilename);
+  var fileToMatch = path.basename(this.baseFilename);
+  var filesToCheck = fs.readdirSync(dirToScan).filter(function (file) {
+    return file.indexOf(fileToMatch) > -1;
+  });
+  for (var i = 0; i < filesToCheck.length; i++) {
+    if (filesToCheck[i].startsWith(fileToMatch)) {
+      var fileToCheck = path.join(dirToScan, filesToCheck[i]);
+      var fileStats = fs.statSync(fileToCheck);
+      if (fileStats.mtime < oldestDate) {
+        debug("Deleting old log ", filesToCheck);
+        fs.unlinkSync(fileToCheck);
+      }
+    }
+  }
+};
+
 

--- a/lib/DateRollingFileStream.js
+++ b/lib/DateRollingFileStream.js
@@ -124,13 +124,11 @@ DateRollingFileStream.prototype.removeFilesOlderThan = function (oldestDate) {
     return file.indexOf(fileToMatch) > -1;
   });
   for (var i = 0; i < filesToCheck.length; i++) {
-    if (filesToCheck[i].startsWith(fileToMatch)) {
-      var fileToCheck = path.join(dirToScan, filesToCheck[i]);
-      var fileStats = fs.statSync(fileToCheck);
-      if (fileStats.mtime < oldestDate) {
-        debug("Deleting old log ", filesToCheck);
-        fs.unlinkSync(fileToCheck);
-      }
+    var fileToCheck = path.join(dirToScan, filesToCheck[i]);
+    var fileStats = fs.statSync(fileToCheck);
+    if (fileStats.mtime < oldestDate) {
+      debug("Deleting old log ", filesToCheck);
+      fs.unlinkSync(fileToCheck);
     }
   }
 };

--- a/lib/DateRollingFileStream.js
+++ b/lib/DateRollingFileStream.js
@@ -1,126 +1,128 @@
 "use strict";
 var BaseRollingFileStream = require('./BaseRollingFileStream')
-    , debug = require('debug')('streamroller:DateRollingFileStream')
-    , format = require('date-format')
-    , fs = require('fs')
-    , path = require('path')
-    , util = require('util');
+  , debug = require('debug')('streamroller:DateRollingFileStream')
+  , format = require('date-format')
+  , fs = require('fs')
+  , path = require('path')
+  , util = require('util');
 
 module.exports = DateRollingFileStream;
 
 function findTimestampFromFileIfExists(filename, now) {
-    return fs.existsSync(filename) ? fs.statSync(filename).mtime : new Date(now());
+  return fs.existsSync(filename) ? fs.statSync(filename).mtime : new Date(now());
 }
 
 function DateRollingFileStream(filename, pattern, options, now) {
-    debug("Now is ", now);
-    if (pattern && typeof(pattern) === 'object') {
-        now = options;
-        options = pattern;
-        pattern = null;
+  debug("Now is ", now);
+  if (pattern && typeof(pattern) === 'object') {
+    now = options;
+    options = pattern;
+    pattern = null;
+  }
+  this.pattern = pattern || '.yyyy-MM-dd';
+  this.now = now || Date.now;
+  this.lastTimeWeWroteSomething = format.asString(
+    this.pattern,
+    findTimestampFromFileIfExists(filename, this.now)
+  );
+
+  this.baseFilename = filename;
+  this.alwaysIncludePattern = false;
+
+  if (options) {
+    if (options.alwaysIncludePattern) {
+      this.alwaysIncludePattern = true;
+      filename = this.baseFilename + this.lastTimeWeWroteSomething;
     }
-    this.pattern = pattern || '.yyyy-MM-dd';
-    this.now = now || Date.now;
-    this.lastTimeWeWroteSomething = format.asString(
-        this.pattern,
-        findTimestampFromFileIfExists(filename, this.now)
-    );
-
-    this.baseFilename = filename;
-    this.alwaysIncludePattern = false;
-
-    if (options) {
-        if (options.alwaysIncludePattern) {
-            this.alwaysIncludePattern = true;
-            filename = this.baseFilename + this.lastTimeWeWroteSomething;
-        }
-        delete options.alwaysIncludePattern;
-        if (Object.keys(options).length === 0) {
-            options = null;
-        }
+    delete options.alwaysIncludePattern;
+    if (Object.keys(options).length === 0) {
+      options = null;
     }
-    debug("this.now is ", this.now, ", now is ", now);
+  }
+  debug("this.now is ", this.now, ", now is ", now);
 
-    DateRollingFileStream.super_.call(this, filename, options);
+  DateRollingFileStream.super_.call(this, filename, options);
 }
 util.inherits(DateRollingFileStream, BaseRollingFileStream);
 
 DateRollingFileStream.prototype.shouldRoll = function () {
-    var lastTime = this.lastTimeWeWroteSomething,
-        thisTime = format.asString(this.pattern, new Date(this.now()));
+  var lastTime = this.lastTimeWeWroteSomething,
+    thisTime = format.asString(this.pattern, new Date(this.now()));
 
-    debug("DateRollingFileStream.shouldRoll with now = ",
-        this.now(), ", thisTime = ", thisTime, ", lastTime = ", lastTime);
+  debug("DateRollingFileStream.shouldRoll with now = ",
+    this.now(), ", thisTime = ", thisTime, ", lastTime = ", lastTime);
 
-    this.lastTimeWeWroteSomething = thisTime;
-    this.previousTime = lastTime;
+  this.lastTimeWeWroteSomething = thisTime;
+  this.previousTime = lastTime;
 
-    return thisTime !== lastTime;
+  return thisTime !== lastTime;
 };
 
 DateRollingFileStream.prototype.roll = function (filename, callback) {
-    var that = this;
+  var that = this;
 
-    debug("Starting roll");
+  debug("Starting roll");
 
-    if (this.alwaysIncludePattern) {
-        this.filename = this.baseFilename + this.lastTimeWeWroteSomething;
-        this.closeTheStream(this.openTheStream.bind(this, callback));
-    } else {
-        var newFilename = this.baseFilename + this.previousTime;
-        this.closeTheStream(
-            deleteAnyExistingFile.bind(null,
-                renameTheCurrentFile.bind(null,
-                    this.compressIfNeeded.bind(this, newFilename,
-                        removeOldFiles.bind(this,
-                            this.openTheStream.bind(this,
-                                callback))))));
-    }
+  if (this.alwaysIncludePattern) {
+    this.filename = this.baseFilename + this.lastTimeWeWroteSomething;
+    this.closeTheStream(
+      this.compressIfNeeded.bind(this, filename,
+        removeOldFiles.bind(this,
+          this.openTheStream.bind(this, callback))));
+  } else {
+    var newFilename = this.baseFilename + this.previousTime;
+    this.closeTheStream(
+      deleteAnyExistingFile.bind(null,
+        renameTheCurrentFile.bind(null,
+          this.compressIfNeeded.bind(this, newFilename,
+            removeOldFiles.bind(this,
+              this.openTheStream.bind(this, callback))))));
+  }
 
-    function removeOldFiles(cb) {
-        if (this.options.daysToKeep) {
-            var oldestDate = this.now() - (this.options.daysToKeep * (24 * 60 * 60 * 1000));
+  function removeOldFiles(cb) {
+    if (this.options.daysToKeep && this.options.daysToKeep > 0) {
+      var oldestDate = this.now() - (this.options.daysToKeep * (24 * 60 * 60 * 1000));
 
-            // Loop through any log files and delete any whose mtime is earlier than oldestDate
-            var dirToScan = path.dirname(this.baseFilename);
-            var fileToMatch = path.basename(this.baseFilename);
-            var filesToCheck = fs.readdirSync(dirToScan).filter(function (file) {
-                return file.indexOf(fileToMatch) > -1;
-            });
-            for (var i = 0; i < filesToCheck.length; i++) {
-                if (filesToCheck[i].startsWith(fileToMatch)) {
-                    var fileToCheck = path.join(dirToScan, filesToCheck[i]);
-                    var fileStats = fs.statSync(fileToCheck);
-                    if (fileStats.mtime < oldestDate) {
-                        fs.unlinkSync(fileToCheck);
-                    }
-                }
-            }
+      // Loop through any log files and delete any whose mtime is earlier than oldestDate
+      var dirToScan = path.dirname(this.baseFilename);
+      var fileToMatch = path.basename(this.baseFilename);
+      var filesToCheck = fs.readdirSync(dirToScan).filter(function (file) {
+        return file.indexOf(fileToMatch) > -1;
+      });
+      for (var i = 0; i < filesToCheck.length; i++) {
+        if (filesToCheck[i].startsWith(fileToMatch)) {
+          var fileToCheck = path.join(dirToScan, filesToCheck[i]);
+          var fileStats = fs.statSync(fileToCheck);
+          if (fileStats.mtime < oldestDate) {
+            fs.unlinkSync(fileToCheck);
+          }
         }
-        cb();
+      }
     }
+    cb();
+  }
 
-    function deleteAnyExistingFile(cb) {
-        //on windows, you can get a EEXIST error if you rename a file to an existing file
-        //so, we'll try to delete the file we're renaming to first
-        fs.unlink(newFilename, function (err) {
+  function deleteAnyExistingFile(cb) {
+    //on windows, you can get a EEXIST error if you rename a file to an existing file
+    //so, we'll try to delete the file we're renaming to first
+    fs.unlink(newFilename, function (err) {
 
-            //ignore err: if we could not delete, it's most likely that it doesn't exist
-            cb();
-        });
-    }
+      //ignore err: if we could not delete, it's most likely that it doesn't exist
+      cb();
+    });
+  }
 
-    function renameTheCurrentFile(cb) {
-        debug("Renaming the ", filename, " -> ", newFilename);
-        fs.rename(filename, newFilename, cb);
-    }
+  function renameTheCurrentFile(cb) {
+    debug("Renaming the ", filename, " -> ", newFilename);
+    fs.rename(filename, newFilename, cb);
+  }
 };
 
 DateRollingFileStream.prototype.compressIfNeeded = function (filename, cb) {
-    debug("Checking if we need to compress the old file");
-    if (this.options.compress) {
-        this.compress(filename, cb);
-    } else {
-        cb();
-    }
+  debug("Checking if we need to compress the old file");
+  if (this.options.compress) {
+    this.compress(filename, cb);
+  } else {
+    cb();
+  }
 };

--- a/test/DateRollingFileStream-test.js
+++ b/test/DateRollingFileStream-test.js
@@ -368,7 +368,7 @@ describe('DateRollingFileStream', function () {
               day++;
               streams.push(currentStream);
               nextCallback(err);
-            })
+            });
         },
         function (err, n) {
           stream = streams[0];
@@ -406,7 +406,7 @@ describe('DateRollingFileStream', function () {
             },
             function (err) {
               done(err);
-            })
+            });
         });
       });
     });
@@ -451,7 +451,7 @@ describe('DateRollingFileStream', function () {
               day++;
               streams.push(currentStream);
               nextCallback(err);
-            })
+            });
         },
         function (err, n) {
 
@@ -501,7 +501,7 @@ describe('DateRollingFileStream', function () {
           },
           function (err) {
             done(err);
-          })
+          });
       });
     });
   });


### PR DESCRIPTION
I've added a daysToKeep option to the DateRollingFileStream object. 

The setting will be used on log rollover to only keep a certain number of days of logs. It's similar to backups on the RollingFileStream object but more specifically oriented to the day based rolling of files.

I've added tests to confirm the behavior.