### PR TITLE
Better handling of missing directories

### DIFF
--- a/lib/BaseRollingFileStream.js
+++ b/lib/BaseRollingFileStream.js
@@ -2,6 +2,8 @@
 var fs = require('fs')
 , zlib = require('zlib')
 , debug = require('debug')('streamroller:BaseRollingFileStream')
+, mkdirp = require('mkdirp')
+, path = require('path')
 , util = require('util')
 , stream = require('readable-stream');
 
@@ -68,6 +70,7 @@ BaseRollingFileStream.prototype._write = function(chunk, encoding, callback) {
 BaseRollingFileStream.prototype.openTheStream = function(cb) {
   debug("opening the underlying stream");
   var that = this;
+  mkdirp.sync(path.dirname(this.filename));
   this.theStream = fs.createWriteStream(this.filename, this.options);
   this.theStream.on('error', function(err) {
     that.emit('error', err);

--- a/lib/RollingFileStream.js
+++ b/lib/RollingFileStream.js
@@ -89,6 +89,9 @@ RollingFileStream.prototype.roll = function(filename, callback) {
     //roll the backups (rename file.n to file.n+1, where n <= numBackups)
     debug("Renaming the old files");
     fs.readdir(path.dirname(filename), function (err, files) {
+      if (err) {
+        return cb(err);
+      }
       var filesToProcess = files.filter(justTheseFiles).sort(byIndex);
       (function processOne(err) {
         var file = filesToProcess.pop();

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "sandboxed-module": "^0.2.1"
   },
   "dependencies": {
-    "debug": "^0.7.2",
     "date-format": "^0.0.0",
+    "debug": "^0.7.2",
+    "mkdirp": "^0.5.1",
     "readable-stream": "^1.1.7"
   },
   "engines": {

--- a/test/BaseRollingFileStream-test.js
+++ b/test/BaseRollingFileStream-test.js
@@ -72,4 +72,22 @@ describe('BaseRollingFileStream', function() {
       stream.end();
     });
   });
+
+  describe('when the file is in a non-existent directory', function() {
+    var stream;
+    before(function() {
+      var BaseRollingFileStream = require('../lib/BaseRollingFileStream');
+      stream = new BaseRollingFileStream('subdir/test.log');
+    });
+
+    after(function() {
+      fs.unlinkSync('subdir/test.log');
+      fs.rmdir('subdir');
+    });
+
+    it('should create the directory', function() {
+      fs.existsSync('subdir/test.log').should.eql(true);
+      stream.end();
+    });
+  });
 });

--- a/test/RollingFileStream-test.js
+++ b/test/RollingFileStream-test.js
@@ -327,4 +327,31 @@ describe('RollingFileStream', function() {
       });
     });
   });
+
+  describe('when the directory gets deleted', function() {
+    var stream;
+    before(function(done) {
+      stream = new RollingFileStream(path.join('subdir', 'test-rolling-file-stream'), 5, 5);
+      stream.write('initial', 'utf8', done);
+    });
+
+    after(function() {
+      fs.unlinkSync(path.join('subdir', 'test-rolling-file-stream'));
+      fs.rmdirSync('subdir');
+    });
+
+    it('handles directory deletion gracefully', function(done) {
+      stream.theStream.on('error', done);
+
+      remove(path.join('subdir', 'test-rolling-file-stream'), function() {
+        fs.rmdir('subdir', function() {
+          stream.write('rollover', 'utf8', function() {
+            fs.readFileSync(path.join('subdir', 'test-rolling-file-stream'), 'utf8')
+              .should.eql('rollover');
+            done();
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
1) Use `mkdirp` to create the logfile directory before creating the filename. This way we can provide nested subdirectories that may not necessarily exist.
2) If the log directory has been deleted, rolling over currently throws. Instead we should handle this error gracefully and just proceed as usual.