### PR TITLE
"Error: write after end"

### DIFF
--- a/lib/BaseRollingFileStream.js
+++ b/lib/BaseRollingFileStream.js
@@ -49,7 +49,9 @@ BaseRollingFileStream.prototype._write = function(chunk, encoding, callback) {
     debug("writing the chunk to the underlying stream");
     that.currentSize += chunk.length;
     try {
-      that.theStream.write(chunk, encoding, callback);
+      if (that.theStream.writable) {
+        that.theStream.write(chunk, encoding, callback);
+      }
     }
     catch (err){
       debug(err);


### PR DESCRIPTION
Current code overrides two functions:
 - `_write` (called by internal streams code, and reads from internal buffer)
 - `end` (called externally)

So `_write` is called whenever data is fully processed (i.e. `_write` called, then it invokes callback, only then it's called again). `end` is called straight away.

When recipient stream is slow enough, this creates a possibility that `write-write-write-end` calls will actually translate to `_write-_write-end-_write` sequence. Which creates an error because you can't write to a stream that's already closed.

Here's a demo:

```js
var fs = require('fs')
var stream = require('stream')
fs.createWriteStream = function () {
  var s = new stream.Writable()
  s._write = function (data,__,cb) {
    setTimeout(function () {
      console.log(data)
      cb()
    }, 1000)
  }
  return s
}

var rollers = require('streamroller')
var stream = new rollers.RollingFileStream('whatever', Infinity, 3)
stream.write(Date.now() + '\n')
stream.write(Date.now() + '\n')
stream.write(Date.now() + '\n')
stream.write(Date.now() + '\n')
stream.on('error', console.log)
stream.end()

/* Outputs:
<Buffer 31 34 39 34 35 31 33 30 32 35 35 36 30 0a>
Error: write after end
    at writeAfterEnd (_stream_writable.js:191:12)
    at Writable.write (_stream_writable.js:238:5)
    at writeTheChunk (/home/ubuntu/nodeca/node_modules/streamroller/lib/BaseRollingFileStream.js:52:22)
    at RollingFileStream.BaseRollingFileStream._write (/home/ubuntu/nodeca/node_modules/streamroller/lib/BaseRollingFileStream.js:66:5)
*/
```

It happens in practice with real file streams and log4js, which results in annoying "Error: write after end" messages appearing in the console.

One possible solution is: check `theStream.writable` before you write there, that's what I'm using usually.

Issue is probably introduced in this commit:
https://github.com/nomiddlename/streamroller/commit/dbe43c6c2bf401653a985bc3c6fab76826c745ae